### PR TITLE
remove docker system prune

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,4 +1,3 @@
-docker system prune -f # cleanup
 docker container stop zchain
 docker container rm zchain
 docker build . -t zchain


### PR DESCRIPTION
forcing a system prune should not happen in a startup script. it is really dangerous, and could result in significant lost data. we really shouldn't be running prune in a script at all, and definitely not with a force flag. managing local docker data should be up to the user.